### PR TITLE
add rule for mobs spawned by dungeon spawners

### DIFF
--- a/src/main/java/com/mmyzd/nmsot/SpawningEntry.java
+++ b/src/main/java/com/mmyzd/nmsot/SpawningEntry.java
@@ -15,6 +15,7 @@ public class SpawningEntry {
 	public World world;
 	public Block block;
 	public Entity entity;
+	public boolean fromSpawner;
 
 	public void init(LivingSpawnEvent.CheckSpawn event) {
 		x = (int) Math.floor(event.getX());
@@ -26,6 +27,7 @@ public class SpawningEntry {
 		block = blockState.getBlock();
 		damage = block.damageDropped(blockState);
 		entity = event.getEntity();
+		fromSpawner = event.isSpawner();
 	}
 
 }

--- a/src/main/java/com/mmyzd/nmsot/rule/RuleSet.java
+++ b/src/main/java/com/mmyzd/nmsot/rule/RuleSet.java
@@ -187,6 +187,8 @@ public class RuleSet extends Rule {
 				rule = new RuleLight(s);
 			} else if (getTokenEqualsIgnoreCase(s, "daytime")) {
 				rule = new RuleDayTime(s);
+			} else if (getTokenEqualsIgnoreCase(s, "spawner")) {
+				rule = new RuleSpawner();
 			}
 		}
 		if (rule == null)

--- a/src/main/java/com/mmyzd/nmsot/rule/RuleSpawner.java
+++ b/src/main/java/com/mmyzd/nmsot/rule/RuleSpawner.java
@@ -1,0 +1,12 @@
+package com.mmyzd.nmsot.rule;
+
+import com.mmyzd.nmsot.SpawningEntry;
+
+public class RuleSpawner extends Rule {
+
+    @Override
+    public boolean apply(SpawningEntry entry) {
+        return entry.fromSpawner;
+    }
+
+}


### PR DESCRIPTION
i wanted to banish skeletons and zombies from the world at large without breaking dungeon spawners. now this works:

```
    S:blacklistRules <
        mob:skeleton | mob:zombie | mob:zombie_villager
        -spawner
     >
```